### PR TITLE
chore(diagnostic): label is applied due to scope

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -13,6 +13,7 @@ jobs:
     - uses: actions/labeler@main
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        sync-labels: ""
 
   type-scope:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Expected outcome:
1. `diagnostic` label applied due to scope
2. gpanders assigned as reviewer