### PR TITLE
chore: reviewer is added due to manually adding label

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -13,6 +13,7 @@ jobs:
     - uses: actions/labeler@main
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        sync-labels: ""
 
   type-scope:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Expected outcome:
1. `diagnostic` label manually applied
2. gpanders assigned as reviewer