### PR TITLE
test: apply `documentation` when file under `runtime/doc` changes

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -3154,3 +3154,4 @@ nvim_ui_try_resize_grid({grid}, {width}, {height})
                     {height}  The new requested height.
 
  vim:tw=78:ts=8:ft=help:norl:
+Appended text.


### PR DESCRIPTION
Trigger: PR opened -  file `runtime/doc/api.txt` has changed.

Expected outcome:
1. `documentation` label applied
2. clason requested as reviewer