### PR TITLE
ci-test: don't apply `runtime` if other more specific labels are applicable.

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1885,3 +1885,4 @@ lsp.commands = setmetatable({}, {
 
 return lsp
 -- vim:sw=2 ts=2 et
+Appended text.


### PR DESCRIPTION
**Trigger**: PR opened - file `runtime/lua/vim/lsp.lua` is changed.

**Expected outcome**:
1. Label `lua` is applied but not `runtime`