### PR TITLE
labeler: don't apply `runtime` if other more specific labels are applicable.

### DIFF
--- a/runtime/autoload/provider/clipboard.vim
+++ b/runtime/autoload/provider/clipboard.vim
@@ -241,3 +241,4 @@ endfunction
 
 " eval_has_provider() decides based on this variable.
 let g:loaded_clipboard_provider = empty(provider#clipboard#Executable()) ? 1 : 2
+Appended text.


### PR DESCRIPTION
**Trigger**: PR opened - file `runtime/autoload/provider/clipboard.vim` is changed.

**Expected outcome**:
1. Label `clipboard` is applied but not `runtime`