### PR TITLE
labeler: Apply `filetype` label but not `runtime`

### DIFF
--- a/runtime/filetype.lua
+++ b/runtime/filetype.lua
@@ -24,3 +24,4 @@ augroup END
 if not vim.g.ft_ignore_pat then
   vim.g.ft_ignore_pat = "\\.\\(Z\\|gz\\|bz2\\|zip\\|tgz\\)$"
 end
+Appended text.


### PR DESCRIPTION
**Trigger**: PR opened - file `runtime/filetype.lua` is changed.

**Expected outcome**:
1. Label `filetype` is applied but not `runtime`