### PR TITLE
labeler: Apply `filetype` label but not `runtime`

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1619,3 +1619,4 @@ function M.match(name, bufnr)
 end
 
 return M
+Appended text.


### PR DESCRIPTION
**Trigger**: PR opened - file `runtime/lua/vim/filetype.lua` is changed.

**Expected outcome**:
1. Label `filetype` is applied but not `runtime`