### PR TITLE
labeler: don't apply `documentation` if file not in `runtime/doc` changes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -64,4 +64,5 @@
   - runtime/lua/vim/filetype.lua
 
 "runtime":
-  - any: [runtime/**/*, "!runtime/autoload/provider/clipboard.vim"]
+  - "runtime/**/*"
+  - all: ["!runtime/autoload/provider/clipboard.vim"]

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -64,5 +64,4 @@
   - runtime/lua/vim/filetype.lua
 
 "runtime":
-  - "runtime/**/*"
-  - all: ["!runtime/autoload/provider/clipboard.vim"]
+  - all: [runtime/**/*, "!runtime/autoload/provider/clipboard.vim"]

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -64,4 +64,4 @@
   - runtime/lua/vim/filetype.lua
 
 "runtime":
-  - all: [runtime/**/*, "!runtime/autoload/provider/clipboard.vim"]
+  - all: [runtime/**/*, "!runtime/autoload/provider/clipboard.vim", "!runtime/lua/vim/lsp.lua", "!runtime/lua/vim/lsp/*", "!runtime/lua/**/*", "!runtime/lua/vim/treesitter.lua", "!runtime/lua/vim/treesitter/*", "!runtime/lua/vim/diagnostic.lua", "!runtime/doc/*", "!runtime/autoload/provider/clipboard.vim", "!runtime/lua/vim/filetype.lua"]

--- a/runtime/delmenu.vim
+++ b/runtime/delmenu.vim
@@ -29,3 +29,4 @@ unlet! g:menutrans_tags_dialog
 unlet! g:menutrans_textwidth_dialog
 
 " vim: set sw=2 :
+Appended text.

--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -3154,3 +3154,4 @@ nvim_ui_try_resize_grid({grid}, {width}, {height})
                     {height}  The new requested height.
 
  vim:tw=78:ts=8:ft=help:norl:
+Appended text.


### PR DESCRIPTION
**Trigger**: PR opened - files `runtime/doc/api.txt` and `Makefile` is changed.

**Expected outcome**:
1. No labels applied