### PR TITLE
labeler: apply `clipboard` but not `runtime`

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -64,4 +64,5 @@
   - runtime/lua/vim/filetype.lua
 
 "runtime":
-  - any: [runtime/**/*, "!runtime/autoload/provider/clipboard.vim"]
+  - "runtime/**/*"
+  - all: ["!runtime/autoload/provider/clipboard.vim"]

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -64,5 +64,4 @@
   - runtime/lua/vim/filetype.lua
 
 "runtime":
-  - "runtime/**/*"
-  - all: ["!runtime/autoload/provider/clipboard.vim"]
+  - all: [runtime/**/*, "!runtime/autoload/provider/clipboard.vim"]

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -64,4 +64,4 @@
   - runtime/lua/vim/filetype.lua
 
 "runtime":
-  - all: [runtime/**/*, "!runtime/autoload/provider/clipboard.vim"]
+  - all: [runtime/**/*, "!runtime/autoload/provider/clipboard.vim", "!runtime/lua/vim/lsp.lua", "!runtime/lua/vim/lsp/*", "!runtime/lua/**/*", "!runtime/lua/vim/treesitter.lua", "!runtime/lua/vim/treesitter/*", "!runtime/lua/vim/diagnostic.lua", "!runtime/doc/*", "!runtime/autoload/provider/clipboard.vim", "!runtime/lua/vim/filetype.lua"]

--- a/runtime/autoload/provider/clipboard.vim
+++ b/runtime/autoload/provider/clipboard.vim
@@ -241,3 +241,4 @@ endfunction
 
 " eval_has_provider() decides based on this variable.
 let g:loaded_clipboard_provider = empty(provider#clipboard#Executable()) ? 1 : 2
+Appended text.


### PR DESCRIPTION
**Trigger**: PR opened - file `runtime/autoload/provider/clipboard.vim` is changed.

**Expected outcome**:
1. Label `clipboard` is applied but not `runtime`