### PR TITLE
labeler: apply `filetype` label but not `runtime`

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -64,4 +64,5 @@
   - runtime/lua/vim/filetype.lua
 
 "runtime":
-  - any: [runtime/**/*, "!runtime/autoload/provider/clipboard.vim"]
+  - "runtime/**/*"
+  - all: ["!runtime/autoload/provider/clipboard.vim"]

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -64,5 +64,4 @@
   - runtime/lua/vim/filetype.lua
 
 "runtime":
-  - "runtime/**/*"
-  - all: ["!runtime/autoload/provider/clipboard.vim"]
+  - all: [runtime/**/*, "!runtime/autoload/provider/clipboard.vim"]

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -64,4 +64,4 @@
   - runtime/lua/vim/filetype.lua
 
 "runtime":
-  - all: [runtime/**/*, "!runtime/autoload/provider/clipboard.vim"]
+  - all: [runtime/**/*, "!runtime/autoload/provider/clipboard.vim", "!runtime/lua/vim/lsp.lua", "!runtime/lua/vim/lsp/*", "!runtime/lua/**/*", "!runtime/lua/vim/treesitter.lua", "!runtime/lua/vim/treesitter/*", "!runtime/lua/vim/diagnostic.lua", "!runtime/doc/*", "!runtime/autoload/provider/clipboard.vim", "!runtime/lua/vim/filetype.lua"]

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1619,3 +1619,4 @@ function M.match(name, bufnr)
 end
 
 return M
+Appended text.


### PR DESCRIPTION
**Trigger**: PR opened - file `runtime/lua/vim/filetype.lua` is changed.

**Expected outcome**:
1. Label `filetype` is applied but not `runtime`