### PR TITLE
labeler: don't apply `documentation` if file not in `runtime/doc` changes

### DIFF
--- a/runtime/delmenu.vim
+++ b/runtime/delmenu.vim
@@ -29,3 +29,4 @@ unlet! g:menutrans_tags_dialog
 unlet! g:menutrans_textwidth_dialog
 
 " vim: set sw=2 :
+Appended text.

--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -3154,3 +3154,4 @@ nvim_ui_try_resize_grid({grid}, {width}, {height})
                     {height}  The new requested height.
 
  vim:tw=78:ts=8:ft=help:norl:
+Appended text.


### PR DESCRIPTION
**Trigger**: PR opened - files `runtime/doc/api.txt` and `Makefile` is changed.

**Expected outcome**:
1. No labels applied