### PR TITLE
ci-test: reviewer not added on draft PRs if label is added

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,6 +2,9 @@ name: "Pull Request Labeler"
 on:
   pull_request_target:
     types: [opened]
+
+env:
+  TERM: xterm-color
 jobs:
 
   triage:


### PR DESCRIPTION
**Prerequisites**: Open, draft PR

**Trigger**: `diagnostic` label added

**Expected outcome**:
1. No reviewers requested