### PR TITLE
ci-test: reviewer not added on draft PRs if label is added

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -26,6 +26,9 @@ jobs:
       PR_NUMBER: ${{ github.event.pull_request.number }}
       PR_TITLE: ${{ github.event.pull_request.title }}
     steps:
+    - run: |
+        sudo apt-get update
+        sudo apt-get install -y python3 luajit
     - name: "Extract commit type and add as label"
       run: gh pr edit "$PR_NUMBER" --add-label "$(echo "$PR_TITLE" | sed -E 's|([[:alpha:]]+)(\(.*\))?!?:.*|\1|')" || true
     - name: "Extract commit scope and add as label"


### PR DESCRIPTION
**Prerequisites**: Open, draft PR

**Trigger**: `diagnostic` label added

**Expected outcome**:
1. No reviewers requested