### PR TITLE
labeler: don't apply `documentation` if markdown + nondoc file is changed.

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -39,6 +39,7 @@
 
 "documentation":
   - all: ["runtime/doc/*"]
+  - any: ["**/*.md"]
 
 "clipboard":
   - runtime/autoload/provider/clipboard.vim

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -39,7 +39,7 @@
 
 "documentation":
   - all: ["runtime/doc/*"]
-  - any: ["**/*.md"]
+  - all: ["**/*.md"]
 
 "clipboard":
   - runtime/autoload/provider/clipboard.vim

--- a/README.md
+++ b/README.md
@@ -128,3 +128,4 @@ Apache 2.0 license, except for contributions copied from Vim (identified by the
 [Homebrew]: https://formulae.brew.sh/formula/neovim
 
 <!-- vim: set tw=80: -->
+Appended text.

--- a/runtime/delmenu.vim
+++ b/runtime/delmenu.vim
@@ -29,3 +29,4 @@ unlet! g:menutrans_tags_dialog
 unlet! g:menutrans_textwidth_dialog
 
 " vim: set sw=2 :
+Appended text.


### PR DESCRIPTION
**Trigger**: PR opened - files `runtime/delmenu.vim` and `README.md` is changed.

**Expected outcome**:
1. No labels applied